### PR TITLE
fix endless loop

### DIFF
--- a/src/ComposerPlugin.php
+++ b/src/ComposerPlugin.php
@@ -233,6 +233,12 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
                 $this->gitDirectory = $possibleGitDir;
                 return;
             }
+
+            // if we checked the root directory already, break to prevent endless loop
+            if ($path === dirname($path)) {
+                break;
+            }
+
             $path = \dirname($path);
         }
         throw new RuntimeException($this->pluginErrorMessage('git directory not found'));


### PR DESCRIPTION
While checking for possible _.git_ dir the plugin was stuck in an endless loop. If this fix is applied the behaviour should be solved. If _.git_ dir doesn't exist the provided `RuntimeException` will be thrown.