### PR TITLE
Use PHAR-File as executable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   "require": {
     "php": "^7.1",
     "composer-plugin-api": "^1.1",
-    "captainhook/captainhook": "^5.0"
+    "org_heigl/trait-iterator": "^1.1"
   },
   "require-dev": {
     "composer/composer": "*"

--- a/src/Asset/AssetUrl.php
+++ b/src/Asset/AssetUrl.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CaptainHook\Plugin\Composer\Asset;
+
+class AssetUrl
+{
+    private $name;
+
+    private $url;
+
+    public function __construct(string $name, string $url)
+    {
+        $this->name = $name;
+        $this->url = $url;
+    }
+
+    public function getAssetName() : string
+    {
+        return $this->name;
+    }
+
+    public function getAssetUrl() : string
+    {
+        return $this->url;
+    }
+}

--- a/src/Asset/Exception/AssetNotFound.php
+++ b/src/Asset/Exception/AssetNotFound.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CaptainHook\Plugin\Composer\Asset\Exception;
+
+use UnexpectedValueException;
+
+class AssetNotFound extends UnexpectedValueException
+{
+}

--- a/src/Asset/Exception/NoAssetMatchingConstraintFound.php
+++ b/src/Asset/Exception/NoAssetMatchingConstraintFound.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CaptainHook\Plugin\Composer\Asset\Exception;
+
+use UnexpectedValueException;
+
+class NoAssetMatchingConstraintFound extends UnexpectedValueException
+{
+
+}

--- a/src/Asset/Exception/NoAssetsFound.php
+++ b/src/Asset/Exception/NoAssetsFound.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CaptainHook\Plugin\Composer\Asset\Exception;
+
+use UnexpectedValueException;
+
+class NoAssetsFound extends UnexpectedValueException
+{
+
+}

--- a/src/Asset/Exception/TroubleWithGithubApiAccess.php
+++ b/src/Asset/Exception/TroubleWithGithubApiAccess.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CaptainHook\Plugin\Composer\Asset\Exception;
+
+use UnexpectedValueException;
+
+class TroubleWithGithubApiAccess extends UnexpectedValueException
+{
+
+}

--- a/src/Asset/Release/Release.php
+++ b/src/Asset/Release/Release.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CaptainHook\Plugin\Composer\Asset\Release;
+
+use CaptainHook\Plugin\Composer\Asset\AssetUrl;
+use CaptainHook\Plugin\Composer\Asset\Exception\AssetNotFound;
+
+class Release
+{
+    private $version;
+
+    private $assetUrls;
+
+    public function __construct(string $version, AssetUrl ...$assetUrls)
+    {
+        $this->version = $version;
+        $this->assetUrls = $assetUrls;
+    }
+
+    public function getVersion() : string
+    {
+        return $this->version;
+    }
+
+    public function getAssetUrls() : array
+    {
+        return $this->assetUrls;
+    }
+
+    public function hasAsset(string $name) : bool
+    {
+        foreach ($this->assetUrls as $url) {
+            if ($url->getAssetName() === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getAssetUrl(string $name) : AssetUrl
+    {
+        foreach ($this->assetUrls as $url) {
+            if ($url->getAssetName() === $name) {
+                return $url;
+            }
+        }
+
+        throw new AssetNotFound(sprintf(
+            'The asset %s could not be found',
+            $name
+        ));
+    }
+}

--- a/src/Asset/Release/ReleaseList.php
+++ b/src/Asset/Release/ReleaseList.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CaptainHook\Plugin\Composer\Asset\Release;
+
+use Iterator;
+use Org_Heigl\IteratorTrait\IteratorTrait;
+
+class ReleaseList implements Iterator
+{
+    use IteratorTrait;
+
+    private $releases;
+
+    public function addRelease(Release $release) : void
+    {
+        $this->releases[] = $release;
+    }
+
+    /**
+     * Get the array the iterator shall iterate over.
+     *
+     * @return array
+     */
+    protected function & getIterableElement()
+    {
+        return $this->releases;
+    }
+}

--- a/src/Asset/Service/ConvertGithubReleaseListService.php
+++ b/src/Asset/Service/ConvertGithubReleaseListService.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CaptainHook\Plugin\Composer\Asset\Service;
+
+use CaptainHook\Plugin\Composer\Asset\AssetUrl;
+use CaptainHook\Plugin\Composer\Asset\Release\Release;
+use CaptainHook\Plugin\Composer\Asset\Release\ReleaseList;
+use Psr\Http\Message\ResponseInterface;
+
+class ConvertGithubReleaseListService
+{
+    public function getReleaseList(string $response) : ReleaseList
+    {
+        $list = new ReleaseList();
+
+        $json = json_decode($response, true);
+        foreach ($json as $release) {
+            if (empty($release['assets'])) {
+                continue;
+            }
+
+            $version = $release['tag_name'];
+            $files = [];
+
+            foreach ($release['assets'] as $asset) {
+                $files[] = new AssetUrl($asset['name'], $asset['browser_download_url']);
+            }
+
+            $list->addRelease(new Release($version, ...$files));
+        }
+        return $list;
+    }
+}

--- a/src/Asset/Service/GithubService.php
+++ b/src/Asset/Service/GithubService.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CaptainHook\Plugin\Composer\Asset\Service;
+
+use CaptainHook\Plugin\Composer\Asset\Exception\NoAssetMatchingConstraintFound;
+use CaptainHook\Plugin\Composer\Asset\Exception\TroubleWithGithubApiAccess;
+use Exception;
+use function file_get_contents;
+use function stream_context_set_option;
+
+class GithubService
+{
+    private $client;
+
+    private $versionService;
+
+    private $converterService;
+
+    public function __construct(
+        $context,
+        VersionService $versionService,
+        ConvertGithubReleaseListService $converterService
+    ) {
+        $this->context = $context;
+        $this->versionService = $versionService;
+        $this->converterService = $converterService;
+
+        stream_context_set_option($this->context, 'http', 'method', 'GET');
+        stream_context_set_option($this->context, 'http', 'header', 'Accept: application/vnd.github.v3+json');
+        stream_context_set_option($this->context, 'http', 'user_agent', 'AssetFetcher');
+    }
+
+    /**
+     * @throws TroubleWithGithubApiAccess
+     * @throws NoAssetMatchingConstraintFound
+     */
+    public function __invoke(
+        string $user,
+        string $project,
+        string $file,
+        string $constraint = null
+    ) : array {
+        try {
+            $result = file_get_contents(sprintf(
+                '%3$s/repos/%1$s/%2$s/releases',
+                $user,
+                $project,
+                'https://api.github.com'
+            ), false, $this->context);
+        } catch (Exception $e) {
+            throw new TroubleWithGithubApiAccess(
+                'Something went south while accessing the Github-API',
+                400,
+                $e
+            );
+        }
+
+        $result = $this->converterService->getReleaseList($result);
+
+        $asset = $this->versionService->getLatestAssetForConstraintFromResult(
+            $result,
+            $constraint
+        );
+
+        return [
+            'version' => $asset->getVersion(),
+            'url' => $asset->getAssetUrl($file)->getAssetUrl(),
+        ];
+    }
+}

--- a/src/Asset/Service/VersionService.php
+++ b/src/Asset/Service/VersionService.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CaptainHook\Plugin\Composer\Asset\Service;
+
+use CaptainHook\Plugin\Composer\Asset\Exception\NoAssetMatchingConstraintFound;
+use CaptainHook\Plugin\Composer\Asset\Release\Release;
+use CaptainHook\Plugin\Composer\Asset\Release\ReleaseList;
+use Composer\Semver\Comparator;
+use Composer\Semver\Semver;
+
+class VersionService
+{
+    public function getLatestAssetForConstraintFromResult(ReleaseList $list, string $versionConstraint = null) : Release
+    {
+        $newList = [];
+        /** @var Release $item */
+        foreach ($list as $item) {
+            if (null !== $versionConstraint &&  ! Semver::satisfies($item->getVersion(), $versionConstraint)) {
+                continue;
+            }
+
+            $newList[] = $item;
+        }
+
+        if (count($newList) < 1) {
+            throw new NoAssetMatchingConstraintFound(sprintf(
+                'Could not match Constraint %s',
+                $versionConstraint
+            ));
+        }
+
+        usort($newList, function (Release $a, Release $b) {
+            if (Comparator::greaterThan($a->getVersion(), $b->getVersion())) {
+                return -1;
+            }
+            if (Comparator::lessThan($a->getVersion(), $b->getVersion())) {
+                return 1;
+            }
+
+            return 0;
+        });
+
+        return $newList[0];
+    }
+}


### PR DESCRIPTION
This commit downloads the latest PHAR-File matching the requested
Version-Constraint fixed in the plugin.

This is currently hard-coded to the default captainhook repository.