### PR TITLE
Do not install the captain in CI

### DIFF
--- a/src/ComposerPlugin.php
+++ b/src/ComposerPlugin.php
@@ -137,6 +137,11 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
             $this->io->write('  <comment>plugin is disabled</comment>');
             return;
         }
+        
+        if (getenv('CI') === 'true') {
+            $this->io->write(' <comment>disabling plugin due to CI-environment</comment>');
+            return;
+        }
 
         $this->detectConfiguration();
         $this->detectGitDir();


### PR DESCRIPTION
This modification will not install The Cap'n in CI-Environments (at least those that go with the de-facto standard to set the `CI` environment variable to `true`).

Installing The Cap'n in such environments does not make any sense as there are either no commits going to happen or if so they are going to happen in an automated fashion so breaking those commits is not really helpful. And having  a CI-pipeline run by The Cap'n inside a CI-environment feels... weird to say the least.

This will fix #13 