### PR TITLE
Properly escape executable

### DIFF
--- a/src/ComposerPlugin.php
+++ b/src/ComposerPlugin.php
@@ -210,7 +210,7 @@ class ComposerPlugin implements PluginInterface, EventSubscriberInterface
         $configuration  = ' -c ' . escapeshellarg($this->configuration);
         $repository     = $command === self::COMMAND_INSTALL ? ' -g ' . escapeshellarg($this->gitDirectory) : '';
         $skip           = $command === self::COMMAND_INSTALL ? ' -s' : '';
-        $executable     = str_replace(' ', '\\ ', $this->executable);
+        $executable     = escapeshellarg($this->executable);
 
         // sub process settings
         $cmd   = $executable . ' ' . $command . $ansi . $interaction . $skip . $configuration . $repository;


### PR DESCRIPTION
Only escaping spaces is not sufficient in cases where the plugin is used from a path containing an ampersand, for example. Using `escapeshellarg()` on the path to the executable should be enough to handle special characters.

We ran into this by coincidence due to a colleague having an ampersand in the path where she tried to do a `composer install`.